### PR TITLE
Add new allocator: Mock Wiremock Allocator v2

### DIFF
--- a/Allocators/recMockAllocator002.json
+++ b/Allocators/recMockAllocator002.json
@@ -1,0 +1,44 @@
+{
+  "address": "f3wiremockallocator002",
+  "name": "Mock Wiremock Allocator v2",
+  "allocator_id": "f3wiremockallocator002",
+  "organization": "Wiremock Labs 2",
+  "pathway_addresses": {
+    "msig": "",
+    "signers": []
+  },
+  "associated_org_addresses": "f410wiremockorgaddr002",
+  "application": {
+    "audit": [
+      "Wiremock Approved"
+    ],
+    "distribution": [
+      "No"
+    ],
+    "tranche_schedule": "Monthly",
+    "required_sps": "3",
+    "required_replicas": "2",
+    "github_handles": [
+      "wiremock-labs-2"
+    ],
+    "allocation_bookkeeping": "https://github.com/filecoin-project/wiremock-bookkeeping-2",
+    "client_contract_address": ""
+  },
+  "history": {
+    "Application Submitted": "",
+    "KYC Submitted": "",
+    "Approved": "",
+    "Declined": "",
+    "DC Allocated": ""
+  },
+  "audits": [
+    {
+      "started": "2025-11-25T14:26:35.000Z",
+      "ended": "",
+      "dc_allocated": "",
+      "outcome": "PENDING",
+      "datacap_amount": 5
+    }
+  ],
+  "old_allocator_id": ""
+}


### PR DESCRIPTION
# Filecoin Plus Allocator Application

## Application Details
| Field | Value |
|-------|-------|
| Applicant | Mock Wiremock Allocator v2 |
| Organization | Wiremock Labs 2 |
| Address | [f3wiremockallocator002](https://filfox.info/en/address/f3wiremockallocator002) |
| GitHub Username | [![GitHub](https://img.shields.io/badge/GitHub-wiremock-labs-2?style=flat-square&logo=github)](https://github.com/wiremock-labs-2) |

## Grant Details
| Field | Value |
|-------|-------|
| DataCap Amount | 5 PiB |
| Allocation Method |  |

---
<sup>This message was automatically generated by the Filecoin Plus Bot. For more information, visit [filecoin.io](https://filecoin.io)</sup>